### PR TITLE
remove .nuxt from exclude, set useUnknownInCatchVariables to false

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "strict": true,
     "noEmit": true,
     "experimentalDecorators": true,
+    "useUnknownInCatchVariables": false,
     "baseUrl": ".",
     "paths": {
       "~/*": ["./*"],
@@ -19,5 +20,5 @@
     },
     "types": ["@nuxt/types", "@types/node"],
   },
-  "exclude": ["node_modules", ".nuxt", "dist"]
+  "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
Remove .nuxt from exclude to not ignor types
set useUnknownInCatchVariables to false to not allow changing the type of the variable in a catch clause from any to unknown